### PR TITLE
fix null cell

### DIFF
--- a/src/scripts/modules/minesweeperview.js
+++ b/src/scripts/modules/minesweeperview.js
@@ -51,6 +51,9 @@ export class MinesweeperView {
         // get the clicked cell
         const cell = e.target.closest('.minesweeper-cell');
 
+        // handle dead zone between cells
+        if (!cell) return;
+
         // already been clicked. Do Nothing.
         if (cell.classList.contains('minesweeper-cell-unrevealed') === false) return;
 


### PR DESCRIPTION
handle case where cell is null in the grid click event (there is a small deadzone in the corner of the cells)